### PR TITLE
Patch formatting and Typo

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1,12 +1,12 @@
 ## Books
-- Computer vision: algorithm and applications, Richard Szeliski.
+- Computer Vision: Algorithms and Applications, Richard Szeliski.
 - Deep Learning, Ian Goodfellow and Yoshua Bengio and Aaron Courville.
-- Deep Learning with Pytorch, Eli Stevens, Luca Antiga, and Thomas Viehmann.
+- Deep Learning with PyTorch, Eli Stevens, Luca Antiga, and Thomas Viehmann.
 - Deep Learning with Python, François Chollet.
 - Kornia: an Open Source Differentiable Computer Vision Library for PyTorch, E. Riba et al.
 - Learning OpenCV, Gary Bradski, Adrian Kaehler.
 - Multi View Geometry, Richard Hartley and Andrew Zisserman.
-- Robotics Vision and Control, Peter Corker.
+- Robotics Vision and Control, Peter Corke.
 
 ## Repos
 - [awesome-NeRF](https://github.com/awesome-NeRF/awesome-NeRF)


### PR DESCRIPTION
Keeping the names of the books with consistent capitalization. Capitalize PyTorch as it is advertised.
Correct Peter Corke's name.

I doubt this will make any difference, but may as well contribute.